### PR TITLE
Release groups and Linux build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,57 @@ If you would rather host the servers yourself, you can add the following to your
 127.0.0.14 login.zunes.me
 ```
 
+# hosting these servers on linux
+
+to use these first install `git`, `screen` and the `dotnet` runtime. installing screen is easy just run:
+```shell
+sudo apt update && sudo apt upgrade -y
+sudo apt install screen git
+```
+
+to install dotnet please look at https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu
+
+now to run the services you can do:
+
+```shell
+cd /opt/; git clone https://github.com/ZuneDev/ZuneNetApi.git && cd ./ZuneNetApi
+bash ./run_all.sh
+```
+
+and to stop them all you can do
+```shell
+bash ./stop_all.sh
+```
+
+They will all run in their own screen sessions, which means you can close your SSH connection, and they will continue to run. Basic commands for managing screen sessions are:
+
+To list all the running screens:
+
+```shell
+screen -ls
+```
+
+To reconnect to a specific screen session:
+
+```shell
+screen -rd <name>
+```
+look at the screen documentation for more information.
+
+
+To access these services, you will need to use a proxy like Nginx and configure the following ports to point to the respective domains. Please note that if you are using your own domain, it cannot be more or less than 7 characters long.
+
+```
+8001 catalog.zunes.me
+8802 catalog-ssl.zunes.me
+8002 commerce.zunes.me
+8003 image.catalog.zunes.me
+8004 socialapi.zunes.me
+8005 mix.zunes.me
+8006 tiles.zunes.me
+8007 login.zunes.me
+```
+
 # Unimplemented endpoints
 
 ## Catalog

--- a/Zune.Net.Catalog.Image/Controllers/ImageController.cs
+++ b/Zune.Net.Catalog.Image/Controllers/ImageController.cs
@@ -3,8 +3,12 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Globalization;
+using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Zune.DB;
 using Zune.Net.Helpers;
@@ -27,7 +31,9 @@ namespace Zune.Net.Catalog.Image.Controllers
         [HttpGet, Route("image/{id}")]
         public async Task<IActionResult> Image(Guid id)
         {
-            string? imageUrl = null;
+            string imageUrl = "";
+
+            //Console.WriteLine(id.ToString());
 
             (var idA, var idB, var idC) = id.GetGuidParts();
             var imageEntry = await _database.GetImageEntryAsync(id);
@@ -53,7 +59,7 @@ namespace Zune.Net.Catalog.Image.Controllers
                 if (images != null && images.Count > idB)
                 {
                     var image = images[idB];
-                    imageUrl = image.Value<string>("uri");
+                    imageUrl = image.Value<string>("uri")??"";
                 }
             }
             else
@@ -66,11 +72,38 @@ namespace Zune.Net.Catalog.Image.Controllers
                 int width = caaSupportedSizes.MinBy(x => Math.Abs(x - requestedWidth));
                 imageUrl = $"https://coverartarchive.org/release/{id}/front-{width}";
             }
+            MemoryStream memStream = new MemoryStream();
+            if (imageUrl != "")
+            {
+                memStream = await httpToMemSreamAsync(imageUrl);
+            }
 
             // Request the image from the API and forward it to the Zune software
-            return imageUrl != null
-                ? Redirect(imageUrl)
+            return (memStream.Length > 0)
+                ? File(memStream.ToArray(), "image/jpg")
                 : NotFound();
+        }
+
+        public async Task<MemoryStream> httpToMemSreamAsync(string url)
+        {
+            HttpClient client = new HttpClient();
+            client.DefaultRequestHeaders.Add("User-Agent", "Zune-4.8");
+            MemoryStream imgMemStream = new MemoryStream();
+            Stream imgStream = new MemoryStream();
+            try
+            {
+                HttpResponseMessage response = await client.GetAsync(url);
+                if (response.IsSuccessStatusCode)
+                {
+                    imgStream = response.Content.ReadAsStream();
+                }
+            }
+            catch (HttpRequestException w)
+            {
+                Console.WriteLine(w.ToString());
+            }
+            imgStream.CopyTo(imgMemStream);
+            return imgMemStream;
         }
 
         [HttpGet, Route("music/artist/{id}/{type}")]

--- a/Zune.Net.Catalog/Controllers/Music/ArtistController.cs
+++ b/Zune.Net.Catalog/Controllers/Music/ArtistController.cs
@@ -71,6 +71,7 @@ namespace Zune.Net.Catalog.Controllers.Music
             return MusicBrainz.GetArtistTracksByMBID(mbid, Request.Path, int.Parse(chunkSizeStrs[0]));
         }
 
+        [HttpGet, Route("{mbid}/appearsOnAlbums")] //Will be modified to own method in next few commits
         [HttpGet, Route("{mbid}/albums")]
         public ActionResult<Feed<Album>> Albums(Guid mbid)
         {
@@ -147,7 +148,7 @@ namespace Zune.Net.Catalog.Controllers.Music
             var images = dc_artist.Value<JToken>("images");
             if (images != null)
             {
-                feed.Entries = images.Select((j, idx) =>
+                feed.Entries = images.OrderBy(j =>(int)j.Value<int>("width")*(int)j.Value<int>("width")).Select((j, idx) =>
                 {
                     // Encode DCID and image index in ID
                     Guid imgId = new(dcid, (short)idx, 0, zero);

--- a/Zune.Net.Catalog/Controllers/Music/ChartController.cs
+++ b/Zune.Net.Catalog/Controllers/Music/ChartController.cs
@@ -1,4 +1,5 @@
 ﻿using Atom.Xml;
+using MetaBrainz.MusicBrainz.Interfaces.Entities;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Linq;
@@ -12,7 +13,7 @@ namespace Zune.Net.Catalog.Controllers.Music
     [Produces(Atom.Constants.ATOM_MIMETYPE)]
     public class ChartController : Controller
     {
-        private const bool useDeezer = true;
+        private const bool useDeezer = false;
 
         [HttpGet, Route("tracks")]
         public async Task<ActionResult<Feed<Track>>> Tracks()
@@ -83,11 +84,11 @@ namespace Zune.Net.Catalog.Controllers.Music
 
             foreach (var dz_album in dz_albums)
             {
-                var mb_release = Deezer.GetMBReleaseByDZAlbum(dz_album);
+                IReleaseGroup mb_release = Deezer.GetMBReleaseGroupByDZAlbum(dz_album);
                 if (mb_release == null)
                     continue;
 
-                var album = MusicBrainz.MBReleaseToAlbum(mb_release, updated: updated);
+                var album = MusicBrainz.MBReleaseGroupToAlbum(mb_release, updated: updated);
                 album.Explicit = dz_album.Value<bool>("explicit_lyrics");
 
                 feed.Entries.Add(album);

--- a/Zune.Net.Catalog/Controllers/Music/FeaturesController.cs
+++ b/Zune.Net.Catalog/Controllers/Music/FeaturesController.cs
@@ -1,4 +1,5 @@
 ﻿using Atom.Xml;
+using MetaBrainz.MusicBrainz.Interfaces.Entities;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Threading.Tasks;
@@ -27,11 +28,11 @@ namespace Zune.Net.Catalog.Controllers.Music
 
             foreach (var dz_album in dz_albums)
             {
-                var mb_release = Deezer.GetMBReleaseByDZAlbum(dz_album);
+                IReleaseGroup mb_release = Deezer.GetMBReleaseGroupByDZAlbum(dz_album);
                 if (mb_release == null)
                     continue;
 
-                var album = MusicBrainz.MBReleaseToAlbum(mb_release, updated: updated);
+                Album album = MusicBrainz.MBReleaseGroupToAlbum(mb_release, updated: updated);
                 album.Explicit = dz_album.Value<bool>("explicit_lyrics");
 
                 feed.Entries.Add(album);

--- a/Zune.Net.Shared/Helpers/Deezer.Album.cs
+++ b/Zune.Net.Shared/Helpers/Deezer.Album.cs
@@ -1,4 +1,5 @@
-﻿using MetaBrainz.MusicBrainz.Interfaces.Entities;
+﻿using MetaBrainz.MusicBrainz.Interfaces;
+using MetaBrainz.MusicBrainz.Interfaces.Entities;
 using Newtonsoft.Json.Linq;
 using System.Linq;
 
@@ -6,11 +7,11 @@ namespace Zune.Net.Helpers
 {
     public partial class Deezer
     {
-        public static IRelease GetMBReleaseByDZAlbum(JToken dz_album)
+        public static IReleaseGroup GetMBReleaseGroupByDZAlbum(JToken dz_album)
         {
             JToken dz_artist = dz_album["artist"];
-            var results = MusicBrainz._query.FindAllReleases(
-                $"artistname:{dz_artist.Value<string>("name")} AND release:{dz_album.Value<string>("title")}", simple: false);
+            IStreamingQueryResults<MetaBrainz.MusicBrainz.Interfaces.Searches.ISearchResult<IReleaseGroup>>results = MusicBrainz._query.FindAllReleaseGroups(
+                $"artistname:{dz_artist.Value<string>("name")} AND releasegroup:{dz_album.Value<string>("title")}", simple: false);
 
             return results.FirstOrDefault()?.Item;
         }

--- a/Zune.Net.Shared/Helpers/Discogs.Artist.cs
+++ b/Zune.Net.Shared/Helpers/Discogs.Artist.cs
@@ -53,7 +53,7 @@ namespace Zune.Net.Helpers
                             var mb_album = MusicBrainz.GetAlbumByMBID(mbid_rel);
                             htmlEquiv = $"<link type=\"Album\" id=\"{mb_album.Id}\">{mb_album.Title}</link>";
                         }
-                        catch (QueryException) { }
+                        catch (Exception e) { Console.WriteLine(e);}
                         break;
 
                     // Artist
@@ -64,7 +64,7 @@ namespace Zune.Net.Helpers
                             var mb_artist = MusicBrainz.GetArtistByMBID(mbid_artist);
                             htmlEquiv = $"<link type=\"Contributor\" id=\"{mb_artist.Id}\">{mb_artist.Title}</link>";
                         }
-                        catch (QueryException) { }
+                        catch (Exception e) { Console.WriteLine(e);}
                         break;
 
                     // Label
@@ -75,7 +75,7 @@ namespace Zune.Net.Helpers
                             // TODO: Label lookup
                             htmlEquiv = $"<link type=\"Label\" id=\"{mbid_label}\">the label</link>";
                         }
-                        catch (QueryException) { }
+                        catch (Exception e) { Console.WriteLine(e);}
                         break;
 
                     // Master

--- a/Zune.Net.Shared/Helpers/MusicBrainz.Artist.cs
+++ b/Zune.Net.Shared/Helpers/MusicBrainz.Artist.cs
@@ -69,7 +69,7 @@ namespace Zune.Net.Helpers
 
         public static Feed<Album> GetArtistAlbumsByMBID(Guid mbid, string requestPath)
         {
-            var results = _query.BrowseAllArtistReleases(mbid, inc: Include.ArtistCredits | Include.ReleaseRelationships);
+            MetaBrainz.MusicBrainz.Interfaces.IStreamingQueryResults<IReleaseGroup> results = _query.BrowseAllArtistReleaseGroups(mbid, inc: Include.ArtistCredits | Include.ReleaseRelationships);
             var updated = DateTime.Now;
             Feed<Album> feed = new()
             {
@@ -86,7 +86,7 @@ namespace Zune.Net.Helpers
             {
                 if (feed.Entries.Count == chunkSize) break;
 
-                feed.Entries.Add(MBReleaseToAlbum(mb_release, updated: updated));
+                feed.Entries.Add(MBReleaseGroupToAlbum(mb_release, updated: updated));
             }
 
             return feed;
@@ -95,11 +95,13 @@ namespace Zune.Net.Helpers
 
         public static Artist MBArtistToArtist(IArtist mb_artist, DateTime? updated = null)
         {
+            String name=mb_artist.Name;
+            if (mb_artist.Disambiguation!=null && mb_artist.Disambiguation!="") name +=" (" + mb_artist.Disambiguation + ")";
             updated ??= DateTime.Now;
             Artist artist = new()
             {
                 Id = mb_artist.Id.ToString(),
-                Title = mb_artist.Name,
+                Title = name,
                 SortTitle = mb_artist.SortName,
                 IsVariousArtist = mb_artist.Id == ARTIST_VARIOUSARTISTS,
                 BiographyLink = "https://bing.com",

--- a/Zune.Net.Shared/Helpers/MusicBrainz.Genre.cs
+++ b/Zune.Net.Shared/Helpers/MusicBrainz.Genre.cs
@@ -1,4 +1,5 @@
 ﻿using Atom.Xml;
+using MetaBrainz.MusicBrainz.Interfaces;
 using MetaBrainz.MusicBrainz.Interfaces.Entities;
 using MetaBrainz.MusicBrainz.Interfaces.Searches;
 using System;
@@ -48,13 +49,13 @@ namespace Zune.Net.Helpers
 
             // Get albums from genre
             int maxNumAlbums = 50;
-            var results = _query.FindAllReleases($"tag:\"{mb_genre.Name}\"").GetEnumerator();
+            IEnumerator<ISearchResult<IReleaseGroup>> results = _query.FindAllReleaseGroups($"tag:\"{mb_genre.Name}\"").GetEnumerator();
 
             // Add results to feed
             while (feed.Entries.Count < maxNumAlbums && results.MoveNext())
             {
-                var mb_release = results.Current.Item;
-                feed.Entries.Add(MBReleaseToAlbum(mb_release, updated: updated));
+                var mb_release_grp = results.Current.Item;
+                feed.Entries.Add(MBReleaseGroupToAlbum(mb_release_grp, updated: updated));
             }
 
             return feed;
@@ -78,13 +79,13 @@ namespace Zune.Net.Helpers
             var mb_genres = genre.Value.Values.GetEnumerator();
             while (feed.Entries.Count < maxNumAlbums && mb_genres.MoveNext())
             {
-                var results = _query.FindAllReleases($"tag:\"{mb_genres.Current}\"").GetEnumerator();
+                IEnumerator<ISearchResult<IReleaseGroup>> results = _query.FindAllReleaseGroups($"tag:\"{mb_genres.Current}\"").GetEnumerator();
 
                 // Add results to feed
                 while (feed.Entries.Count < maxNumAlbums && results.MoveNext())
                 {
-                    var mb_release = results.Current.Item;
-                    feed.Entries.Add(MBReleaseToAlbum(mb_release, updated: updated));
+                    IReleaseGroup mb_release_grp = results.Current.Item;
+                    feed.Entries.Add(MBReleaseGroupToAlbum(mb_release_grp, updated: updated));
                 }
             }
 
@@ -131,7 +132,7 @@ namespace Zune.Net.Helpers
                 // Add results to feed
                 while (feed.Entries.Count < maxNumArtists && results.MoveNext())
                 {
-                    var mb_artist = results.Current.Item;
+                    IArtist mb_artist = results.Current.Item;
                     feed.Entries.Add(MBArtistToArtist(mb_artist, updated: updated));
                 }
             }
@@ -174,7 +175,7 @@ namespace Zune.Net.Helpers
             var mb_genres = genre.Value.Values.GetEnumerator();
             while (feed.Entries.Count < maxNumTracks && mb_genres.MoveNext())
             {
-                var results = _query.FindAllRecordings($"tag:\"{mb_genres.Current}\"").GetEnumerator();
+                IEnumerator<ISearchResult<IRecording>> results = _query.FindAllRecordings($"tag:\"{mb_genres.Current}\"").GetEnumerator();
 
                 // Add results to feed
                 while (feed.Entries.Count < maxNumTracks && results.MoveNext())

--- a/Zune.Net.Shared/Helpers/MusicBrainz.Track.cs
+++ b/Zune.Net.Shared/Helpers/MusicBrainz.Track.cs
@@ -41,7 +41,7 @@ namespace Zune.Net.Helpers
                 var mb_rec = _query.LookupRecording(mbid, Include.Genres | Include.ArtistCredits | Include.Releases | Include.UrlRelationships | Include.Media);
                 return MBRecordingToTrack(mb_rec, includeRights: true);
             }
-            catch (QueryException)
+            catch (Exception)
             {
                 // MusicBrainz Picard likes to put the Track ID instead of the Recording ID
                 var releases = _query.BrowseTrackReleases(mbid, limit: 1, inc: Include.UrlRelationships);

--- a/run_all.sh
+++ b/run_all.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+screen -S Zune.Net.Catalog -dm bash -c 'cd /opt/ZuneNetApi/Zune.Net.Catalog && dotnet run --urls="http://0.0.0.0:8001;https://0.0.0.0:8801"'
+screen -S Zune.Net.Commerce -dm bash -c 'cd /opt/ZuneNetApi/Zune.Net.Commerce && dotnet run --urls="http://0.0.0.0:8002;https://0.0.0.0:8802"'
+screen -S Zune.Net.Catalog.Image -dm bash -c 'cd /opt/ZuneNetApi/Zune.Net.Catalog.Image && dotnet run --urls="http://0.0.0.0:8003;https://0.0.0.0:8803"'
+screen -S Zune.Net.SocialApi -dm bash -c 'cd /opt/ZuneNetApi/Zune.Net.SocialApi && dotnet run --urls="http://0.0.0.0:8004;https://0.0.0.0:8804"'
+screen -S Zune.Net.Mix -dm bash -c 'cd /opt/ZuneNetApi/Zune.Net.Mix && dotnet run --urls="http://0.0.0.0:8005;https://0.0.0.0:8805"'
+screen -S Zune.Net.Tiles -dm bash -c 'cd /opt/ZuneNetApi/Zune.Net.Tiles && dotnet run --urls="http://0.0.0.0:8006;https://0.0.0.0:8806"'
+screen -S Zune.Net.Login -dm bash -c 'cd /opt/ZuneNetApi/Zune.Net.Login && dotnet run --urls="http://0.0.0.0:8007;https://0.0.0.0:8807"'

--- a/stop_all.sh
+++ b/stop_all.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+screen -X -S Zune.Net.Catalog quit
+screen -X -S Zune.Net.Commerce quit
+screen -X -S Zune.Net.Catalog.Image quit
+screen -X -S Zune.Net.SocialApi quit
+screen -X -S Zune.Net.Mix quit
+screen -X -S Zune.Net.Tiles quit
+screen -X -S Zune.Net.Login quit


### PR DESCRIPTION
Changed all calls for releases to release groups, thus avoiding duplicates for albums with multiple releases. Also included 404's changes that provided easy Linux development. Changed Image calls as the Zune software 4.8 wasn't properly following redirects.