### PR TITLE
changes to better support the zune HD's automatic metadata downloads

### DIFF
--- a/Zune.Net.Catalog.Image/Controllers/ImageController.cs
+++ b/Zune.Net.Catalog.Image/Controllers/ImageController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Flurl.Http;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Concurrent;
@@ -65,11 +66,19 @@ namespace Zune.Net.Catalog.Image.Controllers
                 imageUrl = $"https://coverartarchive.org/release/{id}/front-{width}";
             }
 
-            // Request the image from the API and forward it to the Zune software
-            return imageUrl != null
-                ? Redirect(imageUrl)
-                : NotFound();
-        }
+			// Request the image from the API and forward it to the Zune software
+			if (imageUrl != null)
+			{
+				var imgResponse = await imageUrl.GetAsync();
+				if (imgResponse.StatusCode != 200)
+					return StatusCode(imgResponse.StatusCode);
+				return File(await imgResponse.GetStreamAsync(), "image/jpeg");
+			}
+			else
+			{
+				return StatusCode(500);
+			}
+		}
 
         [HttpGet, Route("music/artist/{id}/{type}")]
         public async Task<IActionResult> ArtistImage(string id, string type)
@@ -86,9 +95,18 @@ namespace Zune.Net.Catalog.Image.Controllers
                     .Value<string>("uri");
             }
 
-            return imageUrl != null
-                ? Redirect(imageUrl)
-                : NotFound();
-        }
+			// Request the image from the API and forward it to the Zune software
+			if (imageUrl != null)
+			{
+				var imgResponse = await imageUrl.GetAsync();
+				if (imgResponse.StatusCode != 200)
+					return StatusCode(imgResponse.StatusCode);
+				return File(await imgResponse.GetStreamAsync(), "image/jpeg");
+			}
+			else
+			{
+				return StatusCode(500);
+			}
+		}
     }
 }

--- a/Zune.Net.Catalog/Controllers/Music/ArtistController.cs
+++ b/Zune.Net.Catalog/Controllers/Music/ArtistController.cs
@@ -15,10 +15,8 @@ namespace Zune.Net.Catalog.Controllers.Music
     [Produces(Atom.Constants.ATOM_MIMETYPE)]
     public class ArtistController : Controller
     {
-        private readonly ZuneNetContext _database;
-        public ArtistController(ZuneNetContext database)
+        public ArtistController()
         {
-            _database = database;
         }
 
         [HttpGet, Route("")]
@@ -46,12 +44,8 @@ namespace Zune.Net.Catalog.Controllers.Music
                 if (dc_artist_image != null)
                 {
                     string artistImageUrl = dc_artist_image.Value<string>("uri");
-                    var artistImageEntry = await _database.AddImageAsync(artistImageUrl);
+                    //var artistImageEntry = await _database.AddImageAsync(artistImageUrl);
 
-                    artist.BackgroundImage = new()
-                    {
-                        Id = artistImageEntry.Id
-                    };
                 }
             }
 
@@ -92,7 +86,8 @@ namespace Zune.Net.Catalog.Controllers.Music
             return feed;
         }
 
-        [HttpGet, Route("{mbid}/primaryImage")]
+		[HttpGet, Route("{mbid}/deviceBackgroundImage")]
+		[HttpGet, Route("{mbid}/primaryImage")]
         public async Task<ActionResult> PrimaryImage(Guid mbid)
         {
             (var dc_artist, var mb_artist) = await Discogs.GetDCArtistByMBID(mbid);
@@ -106,7 +101,7 @@ namespace Zune.Net.Catalog.Controllers.Music
             return File(await imgResponse.GetStreamAsync(), "image/jpeg");
         }
 
-        [HttpGet, Route("{mbid}/biography")]
+		[HttpGet, Route("{mbid}/biography")]
         public async Task<ActionResult<Entry>> Biography(Guid mbid)
         {
             (var dc_artist, var mb_artist) = await Discogs.GetDCArtistByMBID(mbid);

--- a/Zune.Net.Catalog/Controllers/Music/ArtistController.cs
+++ b/Zune.Net.Catalog/Controllers/Music/ArtistController.cs
@@ -1,4 +1,4 @@
-﻿using Atom.Xml;
+using Atom.Xml;
 using Flurl.Http;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json.Linq;
@@ -15,8 +15,10 @@ namespace Zune.Net.Catalog.Controllers.Music
     [Produces(Atom.Constants.ATOM_MIMETYPE)]
     public class ArtistController : Controller
     {
-        public ArtistController()
+        private readonly ZuneNetContext _database;
+        public ArtistController(ZuneNetContext database)
         {
+            _database = database;
         }
 
         [HttpGet, Route("")]
@@ -44,8 +46,12 @@ namespace Zune.Net.Catalog.Controllers.Music
                 if (dc_artist_image != null)
                 {
                     string artistImageUrl = dc_artist_image.Value<string>("uri");
-                    //var artistImageEntry = await _database.AddImageAsync(artistImageUrl);
+                    var artistImageEntry = await _database.AddImageAsync(artistImageUrl);
 
+                    artist.BackgroundImage = new()
+                    {
+                        Id = artistImageEntry.Id
+                    };
                 }
             }
 
@@ -86,8 +92,8 @@ namespace Zune.Net.Catalog.Controllers.Music
             return feed;
         }
 
-		[HttpGet, Route("{mbid}/deviceBackgroundImage")]
-		[HttpGet, Route("{mbid}/primaryImage")]
+ 	[HttpGet, Route("{mbid}/deviceBackgroundImage")]
+        [HttpGet, Route("{mbid}/primaryImage")]
         public async Task<ActionResult> PrimaryImage(Guid mbid)
         {
             (var dc_artist, var mb_artist) = await Discogs.GetDCArtistByMBID(mbid);
@@ -101,7 +107,7 @@ namespace Zune.Net.Catalog.Controllers.Music
             return File(await imgResponse.GetStreamAsync(), "image/jpeg");
         }
 
-		[HttpGet, Route("{mbid}/biography")]
+        [HttpGet, Route("{mbid}/biography")]
         public async Task<ActionResult<Entry>> Biography(Guid mbid)
         {
             (var dc_artist, var mb_artist) = await Discogs.GetDCArtistByMBID(mbid);


### PR DESCRIPTION
this PR changes the image controllers to return the image directly (since the zune HD doesn't support modern HTTPS, so redirecting to discogs won't work), and adds the /deviceBackgroundImage endpoint, which is used for the main artist background image.

this is a relatively bare-bones commit, you may want to implement other mechanisms such as caching to speed things up a bit