### PR TITLE
Correct logic error in Discogs.Artist MBID mapping

### DIFF
--- a/Zune.Net.Shared/Helpers/Discogs.Artist.cs
+++ b/Zune.Net.Shared/Helpers/Discogs.Artist.cs
@@ -30,7 +30,7 @@ namespace Zune.Net.Helpers
         public static async Task<JObject> GetDCArtistByMBID(Guid mbid, IdMapper mapper)
         {
             var artistIds = await mapper.GetArtistIdsByMbidAsync(mbid);
-            if (int.TryParse(artistIds?.Discogs, out var dcid))
+            if (!int.TryParse(artistIds?.Discogs, out var dcid))
                 return null;
 
             return await GetDCArtistByDCID(dcid);


### PR DESCRIPTION
This PR fixes a simple error that caused all endpoints relying on artist MBID to DCID mapping (such as artist images and bios) to fail.